### PR TITLE
Implemented taxi lookahead

### DIFF
--- a/src/cameracommands/taxilookaheadcameracommand.cpp
+++ b/src/cameracommands/taxilookaheadcameracommand.cpp
@@ -1,0 +1,123 @@
+#include <algorithm>
+
+#include <CHeaders/XPLM/XPLMDataAccess.h>
+#include <CHeaders/XPLM/XPLMUtilities.h>
+
+#include "helpers.h"
+#include "cameraposition.h"
+#include "interfaces/ivisitor.h"
+#include "cameracommands/taxilookaheadcameracommand.h"
+
+TaxiLookAheadCameraCommand::TaxiLookAheadCameraCommand()
+{
+    // Setup the datarefs
+    mOnGroundDataRef    = XPLMFindDataRef("sim/flightmodel/failures/onground_any");
+    mTurnDataRef        = XPLMFindDataRef("sim/flightmodel/position/R");
+    mRudderDataRef      = XPLMFindDataRef("sim/joystick/yoke_heading_ratio");
+    mGroundSpeedDataRef = XPLMFindDataRef("sim/flightmodel/position/groundspeed");
+
+    // Setup the private vars
+    mRudderResponse     = 25;
+    mTurnResponse       = 25;
+    mMaxTaxiSpeed       = 20;
+    mLastYaw            = 0;
+    mLastRoll           = 0;
+}
+
+TaxiLookAheadCameraCommand::~TaxiLookAheadCameraCommand()
+{
+    //dtor
+}
+
+void TaxiLookAheadCameraCommand::execute(CameraPosition &position)
+{
+    (void)position;
+
+    float acc, rudderAcc, turnAcc, groundSpeedAcc, currentTurn, currentRudder, currentGroundSpeed;
+
+    // Restore the initial yaw & roll
+    position.yaw   -= mLastYaw;
+    position.roll  -= mLastRoll;
+
+    // Exit if disabled
+    if (!pEnabled)
+    {
+        // Reset the state vars
+        mLastYaw        = 0;
+        mLastRoll       = 0;
+        return;
+    }
+
+    if (XPLMGetDatai(mOnGroundDataRef)) {
+        currentTurn             = XPLMGetDataf(mTurnDataRef);
+        currentRudder           = XPLMGetDataf(mRudderDataRef);
+        currentGroundSpeed      = XPLMGetDataf(mGroundSpeedDataRef);
+    } else {
+        currentTurn             = 0;
+        currentRudder           = 0;
+        currentGroundSpeed      = 0;
+    }
+
+    // Rudder
+    mRudderFilter.insert(mRudderFilter.begin(), currentRudder);
+    if( mRudderFilter.size() > 30 )
+        mRudderFilter.pop_back();
+    rudderAcc = average(mRudderFilter) * ( mRudderResponse / 100.0f ) * 90.0f;
+
+    // Turn
+    mTurnFilter.insert(mTurnFilter.begin(), currentTurn);
+    if( mTurnFilter.size() > 30 )
+        mTurnFilter.pop_back();
+    turnAcc = average(mTurnFilter) * ( mTurnResponse / 25.0f );
+
+    // Ground speed
+    mGroundSpeedFilter.insert(mGroundSpeedFilter.begin(), currentGroundSpeed);
+    if( mGroundSpeedFilter.size() > 10 )
+        mGroundSpeedFilter.pop_back();
+    groundSpeedAcc = average(mGroundSpeedFilter);
+
+    // Blend the effect out based on the ground speed (max of 20m/sec)
+    acc = ( turnAcc + rudderAcc ) * 0.5f * ( 1.0f - std::max( 0.0f, std::min( groundSpeedAcc / mMaxTaxiSpeed, 1.0f ) ) );
+
+    // Cache yaw & roll
+    mLastYaw       = acc;
+    mLastRoll      = acc * 0.125f;
+
+    position.yaw  += mLastYaw;
+    position.roll += mLastRoll;
+}
+
+void TaxiLookAheadCameraCommand::accept(IVisitor &visitor)
+{
+    visitor.visit(*this);
+}
+
+void TaxiLookAheadCameraCommand::set_rudder_response(float response)
+{
+    mRudderResponse = response;
+}
+
+float TaxiLookAheadCameraCommand::get_rudder_response() const
+{
+    return mRudderResponse;
+}
+
+void TaxiLookAheadCameraCommand::set_turn_response(float response)
+{
+    mTurnResponse = response;
+}
+
+float TaxiLookAheadCameraCommand::get_turn_response() const
+{
+    return mTurnResponse;
+}
+
+void TaxiLookAheadCameraCommand::set_max_taxi_speed(float speed)
+{
+    mMaxTaxiSpeed = speed;
+}
+
+float TaxiLookAheadCameraCommand::get_max_taxi_speed() const
+{
+    return mMaxTaxiSpeed;
+}

--- a/src/cameracommands/taxilookaheadcameracommand.h
+++ b/src/cameracommands/taxilookaheadcameracommand.h
@@ -22,18 +22,20 @@ class TaxiLookAheadCameraCommand : public CameraCommand
         float get_rudder_response() const;
         void set_turn_response(float);
         float get_turn_response() const;
-        void set_max_taxi_speed(float);
-        float get_max_taxi_speed() const;
+        void set_lean_response(float);
+        float get_lean_response() const;
     protected:
     private:
         std::vector<float> mRudderFilter;
         std::vector<float> mTurnFilter;
         std::vector<float> mGroundSpeedFilter;
+        float mLastZ;
+        float mLastY;
         float mLastYaw;
         float mLastRoll;
         float mTurnResponse;
         float mRudderResponse;
-        float mMaxTaxiSpeed;
+        float mLeanResponse;
         XPLMDataRef mOnGroundDataRef;
         XPLMDataRef mTurnDataRef;
         XPLMDataRef mGroundSpeedDataRef;

--- a/src/cameracommands/taxilookaheadcameracommand.h
+++ b/src/cameracommands/taxilookaheadcameracommand.h
@@ -1,0 +1,43 @@
+#ifndef TAXILOOKAHEADCAMERACOMMAND_H
+#define TAXILOOKAHEADCAMERACOMMAND_H
+
+#include <vector>
+
+#include <CHeaders/XPLM/XPLMDataAccess.h>
+
+#include "cameracommands/cameracommand.h"
+#include "cameraposition.h"
+
+class TaxiLookAheadCameraCommand : public CameraCommand
+{
+    public:
+        /** Default constructor */
+        TaxiLookAheadCameraCommand();
+        /** Default destructor */
+        virtual ~TaxiLookAheadCameraCommand();
+        void execute(CameraPosition&);
+        void accept(IVisitor&);
+        /** Implementation methods */
+        void set_rudder_response(float);
+        float get_rudder_response() const;
+        void set_turn_response(float);
+        float get_turn_response() const;
+        void set_max_taxi_speed(float);
+        float get_max_taxi_speed() const;
+    protected:
+    private:
+        std::vector<float> mRudderFilter;
+        std::vector<float> mTurnFilter;
+        std::vector<float> mGroundSpeedFilter;
+        float mLastYaw;
+        float mLastRoll;
+        float mTurnResponse;
+        float mRudderResponse;
+        float mMaxTaxiSpeed;
+        XPLMDataRef mOnGroundDataRef;
+        XPLMDataRef mTurnDataRef;
+        XPLMDataRef mGroundSpeedDataRef;
+        XPLMDataRef mRudderDataRef;
+};
+
+#endif // GROUNDROLLCAMERACOMMAND_H

--- a/src/cameracontrol.cpp
+++ b/src/cameracontrol.cpp
@@ -15,6 +15,7 @@
 #include "cameracommands/gforcecameracommand.h"
 #include "cameracommands/lookaheadcameracommand.h"
 #include "cameracommands/groundrollcameracommand.h"
+#include "cameracommands/taxilookaheadcameracommand.h"
 #include "cameracommands/guncameracommand.h"
 #include "cameracommands/pistonenginecameracommand.h"
 #include "cameracommands/rotorcameracommand.h"
@@ -38,6 +39,7 @@ CameraControl::CameraControl()
     mCommands.push_back(new PistonEngineCameraCommand);
     mCommands.push_back(new RotorCameraCommand);
     mCommands.push_back(new GroundRollCameraCommand);
+    mCommands.push_back(new TaxiLookAheadCameraCommand);
     mCommands.push_back(new GunCameraCommand);
     mCommands.push_back(new TouchdownCameraCommand);
     // Store the size in a private property

--- a/src/interfaces/ivisitor.h
+++ b/src/interfaces/ivisitor.h
@@ -8,6 +8,7 @@ class PistonEngineCameraCommand;
 class RotorCameraCommand;
 class GunCameraCommand;
 class GroundRollCameraCommand;
+class TaxiLookAheadCameraCommand;
 class TouchdownCameraCommand;
 class IVisitor
 {
@@ -23,6 +24,7 @@ class IVisitor
         virtual void visit(RotorCameraCommand&) = 0;
         virtual void visit(GunCameraCommand&) = 0;
         virtual void visit(GroundRollCameraCommand&) = 0;
+        virtual void visit(TaxiLookAheadCameraCommand&) = 0;
         virtual void visit(TouchdownCameraCommand&) = 0;
 };
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -88,7 +88,7 @@ void Menu::visit(CameraControl &control)
     int w, h, x1, x2;
     XPWidgetID subw;
     XPLMGetScreenSize(&w, &h);
-    mHeight = (control.error() ? 710 : 820) + mAdsHeight;
+    mHeight = (control.error() ? 710 : 660) + mAdsHeight;
     mLeft = (w - mWidth) / 2;
     mTop = (h + mHeight) / 2;
     mRight = mLeft + mWidth;
@@ -139,7 +139,7 @@ void Menu::visit(CameraControl &control)
     // Set the subwindow top like main top minus the gforce height,
     // the engine vibrations height, the ground roll height, the touchdown height, the piston engine height, the roto height
     // and some padding
-    y = mTop - 180 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10;
+    y = mTop - 180 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10;
     x1 = mLeft + 20;
     x2 = mRight - 20;
     subw = XPCreateWidget(mLeft + 10, y, mRight - 10, y - 60, 1, "Compatibility", 0, mWidgetId, xpWidgetClass_SubWindow);
@@ -303,7 +303,7 @@ void Menu::visit(LookAheadCameraCommand &command)
     int x1, x2, y = mTop - 180 - 10;
 
     mLookAheadCameraCommand = &command;
-    subw = XPCreateWidget(mLeft + 10, y, mRight - 10, y - 70, 1, "LookAhead Effect Settings",  0, mWidgetId, xpWidgetClass_SubWindow);
+    subw = XPCreateWidget(mLeft + 10, y, mRight - ( mWidth / 2 ) - 10, y - 70, 1, "LookAhead Effect Settings",  0, mWidgetId, xpWidgetClass_SubWindow);
     XPSetWidgetProperty(subw, xpProperty_SubWindowType, xpSubWindowStyle_SubWindow);
 
     x1 = mLeft + 20;
@@ -327,7 +327,7 @@ void Menu::visit(LookAheadCameraCommand &command)
     // Add the sensitivity label + scrollbar
     y = y - 20;
     sprintf(buffer, "Lookahead maximum angle: %.0f degrees", mLookAheadCameraCommand->get_response());
-    lookaheadLabel = XPCreateWidget(x1 - 5, y, x2, y - 10, 1, buffer, 0, mWidgetId, xpWidgetClass_Caption);
+    lookaheadLabel = XPCreateWidget(x1 - 5, y, x2 - ( mWidth / 2 ), y - 10, 1, buffer, 0, mWidgetId, xpWidgetClass_Caption);
     // On message received update the label
     XPAddWidgetCallback(lookaheadLabel, [](XPWidgetMessage inMessage, XPWidgetID inWidget, intptr_t, intptr_t) -> int {
         if (inMessage == xpMsg_UserStart + UPDATE_GFORCE_LOOKAHEAD) {
@@ -339,7 +339,7 @@ void Menu::visit(LookAheadCameraCommand &command)
         return 0;
     });
     y = y - 20;
-    lookaheadScrollbar = XPCreateWidget(x1 + 5, y, x2 - 5, y - 10, 1, "", 0, mWidgetId, xpWidgetClass_ScrollBar);
+    lookaheadScrollbar = XPCreateWidget(x1 + 5, y, x2 - ( mWidth / 2 ) - 5, y - 10, 1, "", 0, mWidgetId, xpWidgetClass_ScrollBar);
     XPSetWidgetProperty(lookaheadScrollbar, xpProperty_ScrollBarMin, 1);
     XPSetWidgetProperty(lookaheadScrollbar, xpProperty_ScrollBarMax, 90);
     XPSetWidgetProperty(lookaheadScrollbar, xpProperty_ScrollBarSliderPosition, (int)command.get_response());
@@ -368,7 +368,7 @@ void Menu::visit(GroundRollCameraCommand &command)
     char buffer[16];
 
     mGroundRollCameraCommand = &command;
-    subw = XPCreateWidget(mLeft + 10, y, mRight - 10, y - 70, 1, "Ground Roll Shaking Settings",  0, mWidgetId, xpWidgetClass_SubWindow);
+    subw = XPCreateWidget( mLeft + 10, y, mRight - ( mWidth / 2 ) - 10, y - 70, 1, "Ground Roll Shaking Settings",  0, mWidgetId, xpWidgetClass_SubWindow);
     XPSetWidgetProperty(subw, xpProperty_SubWindowType, xpSubWindowStyle_SubWindow);
 
     x1 = mLeft + 20;
@@ -392,7 +392,7 @@ void Menu::visit(GroundRollCameraCommand &command)
     // Add the response label + scrollbar
     y = y - 20;
     sprintf(buffer, "Response: %.0f", mGroundRollCameraCommand->get_response());
-    responseLabel = XPCreateWidget(x1, y, x2, y - 10, 1, buffer, 0, mWidgetId, xpWidgetClass_Caption);
+    responseLabel = XPCreateWidget(x1, y, x2 - ( mWidth / 2 ), y - 10, 1, buffer, 0, mWidgetId, xpWidgetClass_Caption);
     // On message received update the label
     XPAddWidgetCallback(responseLabel, [](XPWidgetMessage inMessage, XPWidgetID inWidget, intptr_t, intptr_t) -> int {
         if (inMessage == xpMsg_UserStart + UPDATE_GROUNDROLL) {
@@ -404,7 +404,7 @@ void Menu::visit(GroundRollCameraCommand &command)
         return 0;
     });
     y = y - 20;
-    responseScrollbar = XPCreateWidget(x1 + 5, y, x2 - 5, y - 10, 1, "", 0, mWidgetId, xpWidgetClass_ScrollBar);
+    responseScrollbar = XPCreateWidget(x1 + 5, y, x2 - ( mWidth / 2 ) - 5, y - 10, 1, "", 0, mWidgetId, xpWidgetClass_ScrollBar);
     XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarMin, 1);
     XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarMax, 100);
     XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarSliderPosition, (int)command.get_response());
@@ -425,17 +425,17 @@ void Menu::visit(TaxiLookAheadCameraCommand &command)
     XPWidgetID subw;
     int x1, x2;
     // Set the subwindow top like main top minus the gforce height
-    int y = mTop - 180 - 10 - 70 - 10 - 70 - 10;
+    int y = mTop - 180 - 10;
     XPWidgetID enableButton;
     XPWidgetID responseScrollbar;
     XPWidgetID responseLabel;
     char buffer[32];
 
     mTaxiLookAheadCameraCommand = &command;
-    subw = XPCreateWidget(mLeft + 10, y, mRight - 10, y - 150, 1, "Taxi LookAhead Settings",  0, mWidgetId, xpWidgetClass_SubWindow);
+    subw = XPCreateWidget(mLeft + ( mWidth / 2 ) + 10, y, mRight - 10, y - 70 - 10 - 70, 1, "Taxi LookAhead Settings",  0, mWidgetId, xpWidgetClass_SubWindow);
     XPSetWidgetProperty(subw, xpProperty_SubWindowType, xpSubWindowStyle_SubWindow);
 
-    x1 = mLeft + 20;
+    x1 = mLeft + ( mWidth / 2 ) + 20;
     x2 = mRight - 20;
 
     // Add the enable checkbox
@@ -513,15 +513,15 @@ void Menu::visit(TaxiLookAheadCameraCommand &command)
         return 0;
     });
 
-    // Add the turn response label + scrollbar
+    // Add the lean response label + scrollbar
     y = y - 20;
-    sprintf(buffer, "Max taxi speed: %.0f knots", mTaxiLookAheadCameraCommand->get_max_taxi_speed());
+    sprintf(buffer, "Lean Response: %.0f", mTaxiLookAheadCameraCommand->get_lean_response());
     responseLabel = XPCreateWidget(x1, y, x2, y - 10, 1, buffer, 0, mWidgetId, xpWidgetClass_Caption);
     // On message received update the label
     XPAddWidgetCallback(responseLabel, [](XPWidgetMessage inMessage, XPWidgetID inWidget, intptr_t, intptr_t) -> int {
         if (inMessage == xpMsg_UserStart + UPDATE_TAXI_LOOKAHEAD) {
             char mbuffer[32];
-            sprintf(mbuffer, "Max taxi speed: %.0f knots", Menu::mInstance->mTaxiLookAheadCameraCommand->get_max_taxi_speed());
+            sprintf(mbuffer, "Lean Response: %.0f", Menu::mInstance->mTaxiLookAheadCameraCommand->get_lean_response());
             XPSetWidgetDescriptor(inWidget, mbuffer);
             return 1;
         }
@@ -531,12 +531,12 @@ void Menu::visit(TaxiLookAheadCameraCommand &command)
     responseScrollbar = XPCreateWidget(x1 + 5, y, x2 - 5, y - 10, 1, "", 0, mWidgetId, xpWidgetClass_ScrollBar);
     XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarMin, 1);
     XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarMax, 100);
-    XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarSliderPosition, (int)command.get_max_taxi_speed());
+    XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarSliderPosition, (int)command.get_lean_response());
     XPSetWidgetProperty(responseScrollbar, xpProperty_ScrollBarType, xpScrollBarTypeSlider);
     XPAddWidgetCallback(responseScrollbar, [](XPWidgetMessage inMessage, XPWidgetID inWidget, intptr_t, intptr_t) -> int {
         int inExit;
         if (inMessage == xpMsg_ScrollBarSliderPositionChanged) {
-            Menu::mInstance->mTaxiLookAheadCameraCommand->set_max_taxi_speed((int)(XPGetWidgetProperty(inWidget, xpProperty_ScrollBarSliderPosition, &inExit)));
+            Menu::mInstance->mTaxiLookAheadCameraCommand->set_lean_response((int)(XPGetWidgetProperty(inWidget, xpProperty_ScrollBarSliderPosition, &inExit)));
             XPSendMessageToWidget(Menu::mInstance->mWidgetId, xpMsg_UserStart + UPDATE_TAXI_LOOKAHEAD, xpMode_Recursive, 0, 0);
             return 1;
         }
@@ -549,7 +549,7 @@ void Menu::visit(TouchdownCameraCommand &command)
     XPWidgetID subw;
     int x1, x2;
     // Set the subwindow top like main top minus the gforce height minus the ground roll height
-    int y = mTop - 180 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10;
+    int y = mTop - 180 - 10 - 70 - 10 - 70 - 10;
     XPWidgetID enableButton;
     XPWidgetID responseScrollbar;
     XPWidgetID responseLabel;
@@ -614,7 +614,7 @@ void Menu::visit(PistonEngineCameraCommand &command)
     XPWidgetID subw;
     int x1, x2;
     // Set the subwindow top like main top minus the gforce height minus some padding and the ground roll height minus the touchdown height
-    int y = mTop - 180 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10;
+    int y = mTop - 180 - 10 - 70 - 10 - 70 - 10 - 70 - 10;
     XPWidgetID enableButton;
     XPWidgetID responseScrollbar;
     XPWidgetID responseLabel;
@@ -679,7 +679,7 @@ void Menu::visit(RotorCameraCommand &command)
     int x1, x2;
     // Set the subwindow top like main top minus the gforce height,
     // the engine vibrations height, the ground roll height, the touchdown height, the piston engine height and some padding
-    int y = mTop - 180 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10;
+    int y = mTop - 180 - 10 - 70 - 10 - 70 - 10 - 70 - 10 - 70 - 10;
     XPWidgetID enableButton;
     XPWidgetID responseScrollbar;
     XPWidgetID responseLabel;

--- a/src/menu.h
+++ b/src/menu.h
@@ -24,6 +24,7 @@ class Menu : public IVisitor
         void visit(RotorCameraCommand&);
         void visit(GunCameraCommand&);
         void visit(GroundRollCameraCommand&);
+        void visit(TaxiLookAheadCameraCommand&);
         void visit(TouchdownCameraCommand&);
     protected:
     private:
@@ -54,6 +55,7 @@ class Menu : public IVisitor
         PistonEngineCameraCommand* mPistonEngineCameraCommand;
         RotorCameraCommand* mRotorCameraCommand;
         GroundRollCameraCommand* mGroundRollCameraCommand;
+        TaxiLookAheadCameraCommand* mTaxiLookAheadCameraCommand;
         TouchdownCameraCommand* mTouchdownCameraCommand;
 };
 

--- a/src/settings/settingsreader.cpp
+++ b/src/settings/settingsreader.cpp
@@ -12,6 +12,7 @@
 #include "cameracommands/lookaheadcameracommand.h"
 #include "cameracommands/pistonenginecameracommand.h"
 #include "cameracommands/groundrollcameracommand.h"
+#include "cameracommands/taxilookaheadcameracommand.h"
 #include "cameracommands/guncameracommand.h"
 #include "cameracommands/rotorcameracommand.h"
 #include "cameracommands/touchdowncameracommand.h"
@@ -82,6 +83,18 @@ void SettingsReader::visit(GroundRollCameraCommand &command)
         command.set_enabled(mMap["cameracommand.groundroll.enabled"].compare("1") == 0);
     if (mMap.find("cameracommand.groundroll.response") != mMap.end())
         command.set_response(atof(mMap["cameracommand.groundroll.response"].c_str()));
+}
+
+void SettingsReader::visit(TaxiLookAheadCameraCommand &command)
+{
+    if (mMap.find("cameracommand.taxilookahead.enabled") != mMap.end())
+        command.set_enabled(mMap["cameracommand.taxilookahead.enabled"].compare("1") == 0);
+    if (mMap.find("cameracommand.taxilookahead.rudder.response") != mMap.end())
+        command.set_rudder_response(atof(mMap["cameracommand.taxilookahead.rudder.response"].c_str()));
+    if (mMap.find("cameracommand.taxilookahead.turn.response") != mMap.end())
+        command.set_turn_response(atof(mMap["cameracommand.taxilookahead.turn.response"].c_str()));
+    if (mMap.find("cameracommand.taxilookahead.speed.max") != mMap.end())
+        command.set_max_taxi_speed(atof(mMap["cameracommand.taxilookahead.speed.max"].c_str()));
 }
 
 void SettingsReader::visit(TouchdownCameraCommand &command)

--- a/src/settings/settingsreader.cpp
+++ b/src/settings/settingsreader.cpp
@@ -93,8 +93,8 @@ void SettingsReader::visit(TaxiLookAheadCameraCommand &command)
         command.set_rudder_response(atof(mMap["cameracommand.taxilookahead.rudder.response"].c_str()));
     if (mMap.find("cameracommand.taxilookahead.turn.response") != mMap.end())
         command.set_turn_response(atof(mMap["cameracommand.taxilookahead.turn.response"].c_str()));
-    if (mMap.find("cameracommand.taxilookahead.speed.max") != mMap.end())
-        command.set_max_taxi_speed(atof(mMap["cameracommand.taxilookahead.speed.max"].c_str()));
+    if (mMap.find("cameracommand.taxilookahead.lean.response") != mMap.end())
+        command.set_lean_response(atof(mMap["cameracommand.taxilookahead.lean.response"].c_str()));
 }
 
 void SettingsReader::visit(TouchdownCameraCommand &command)

--- a/src/settings/settingsreader.h
+++ b/src/settings/settingsreader.h
@@ -20,6 +20,7 @@ class SettingsReader : public IVisitor
         void visit(RotorCameraCommand&);
         void visit(GunCameraCommand&);
         void visit(GroundRollCameraCommand&);
+        void visit(TaxiLookAheadCameraCommand&);
         void visit(TouchdownCameraCommand&);
     protected:
     private:

--- a/src/settings/settingswriter.cpp
+++ b/src/settings/settingswriter.cpp
@@ -90,7 +90,7 @@ void SettingsWriter::visit(TaxiLookAheadCameraCommand &command)
         fprintf(mFile, "cameracommand.taxilookahead.enabled=%s\n", command.is_enabled() ? "1" : "0");
         fprintf(mFile, "cameracommand.taxilookahead.rudder.response=%.0f\n", command.get_rudder_response());
         fprintf(mFile, "cameracommand.taxilookahead.turn.response=%.0f\n", command.get_turn_response());
-        fprintf(mFile, "cameracommand.taxilookahead.speed.max=%.0f\n", command.get_max_taxi_speed());
+        fprintf(mFile, "cameracommand.taxilookahead.lean.response=%.0f\n", command.get_lean_response());
     }
 }
 

--- a/src/settings/settingswriter.cpp
+++ b/src/settings/settingswriter.cpp
@@ -8,6 +8,7 @@
 #include "cameracommands/lookaheadcameracommand.h"
 #include "cameracommands/pistonenginecameracommand.h"
 #include "cameracommands/groundrollcameracommand.h"
+#include "cameracommands/taxilookaheadcameracommand.h"
 #include "cameracommands/guncameracommand.h"
 #include "cameracommands/rotorcameracommand.h"
 #include "cameracommands/touchdowncameracommand.h"
@@ -80,6 +81,16 @@ void SettingsWriter::visit(GroundRollCameraCommand &command)
     if (mFile != NULL) {
         fprintf(mFile, "cameracommand.groundroll.enabled=%s\n", command.is_enabled() ? "1" : "0");
         fprintf(mFile, "cameracommand.groundroll.response=%.0f\n", command.get_response());
+    }
+}
+
+void SettingsWriter::visit(TaxiLookAheadCameraCommand &command)
+{
+    if (mFile != NULL) {
+        fprintf(mFile, "cameracommand.taxilookahead.enabled=%s\n", command.is_enabled() ? "1" : "0");
+        fprintf(mFile, "cameracommand.taxilookahead.rudder.response=%.0f\n", command.get_rudder_response());
+        fprintf(mFile, "cameracommand.taxilookahead.turn.response=%.0f\n", command.get_turn_response());
+        fprintf(mFile, "cameracommand.taxilookahead.speed.max=%.0f\n", command.get_max_taxi_speed());
     }
 }
 

--- a/src/settings/settingswriter.h
+++ b/src/settings/settingswriter.h
@@ -21,6 +21,7 @@ class SettingsWriter : public IVisitor
         void visit(RotorCameraCommand&);
         void visit(GunCameraCommand&);
         void visit(GroundRollCameraCommand&);
+        void visit(TaxiLookAheadCameraCommand&);
         void visit(TouchdownCameraCommand&);
     protected:
     private:


### PR DESCRIPTION
A first attempt at implementing #5 

The taxi lookahead is kept separate to the ground roll as suggested in the original request. 

The lookahead is derived from a blend of the rudder input & ground rotation rate in an attempt to orient the view towards the turn. To minimise the distractions that the lookahead would cause during the takeoff phase, the effect is set to fade out with increased ground speed (currently set to 20 knots which should work for most aircrafts).

I have ran a series of tests with both a set of Thrusmaster Rudder pedals as well as a regular twist-style joystick rudder control (X55 Hotas) for sensitivity/response. I experimented with the lookahead effect in isolation as well as with all other ground effects enabled on both GA planes & larger Heavy aircrafts.

The initial responses & max taxi speeds default values were set to what I considered to feel & interact nicely across a variety of aircraft types. 

Suggestions for different default values are of course welcome ; general feedback would also be much appreciated.

Thanks