### PR TITLE
Minimal changeset to fix head roll issues

### DIFF
--- a/src/cameracommands/cameracommand.cpp
+++ b/src/cameracommands/cameracommand.cpp
@@ -60,3 +60,8 @@ float CameraCommand::get_blend_ratio() const
 {
     return mBlendTime / 2;
 }
+
+float CameraCommand::get_last_roll()
+{
+  return 0.0f;
+}

--- a/src/cameracommands/cameracommand.h
+++ b/src/cameracommands/cameracommand.h
@@ -20,6 +20,7 @@ class CameraCommand : public IVisitable
         virtual void on_enable();
         virtual void on_disable();
         void reset_blend();
+        virtual float get_last_roll();
     protected:
         float get_blend_ratio() const;
         bool pEnabled;

--- a/src/cameracommands/gforcecameracommand.cpp
+++ b/src/cameracommands/gforcecameracommand.cpp
@@ -200,3 +200,8 @@ float GForceCameraCommand::get_yaw_response()
 {
     return mYawResponse;
 }
+
+float GForceCameraCommand::get_last_roll()
+{
+  return mLastRoll;
+}

--- a/src/cameracommands/gforcecameracommand.h
+++ b/src/cameracommands/gforcecameracommand.h
@@ -26,6 +26,7 @@ class GForceCameraCommand : public CameraCommand
         float get_yaw_response();
         void on_enable() override;
         void on_disable() override;
+        virtual float get_last_roll();
     protected:
     private:
         unsigned int mDamper;

--- a/src/cameracommands/groundrollcameracommand.cpp
+++ b/src/cameracommands/groundrollcameracommand.cpp
@@ -98,3 +98,8 @@ float GroundRollCameraCommand::get_response()
 {
     return mResponse;
 }
+
+float GroundRollCameraCommand::get_last_roll()
+{
+  return mLastRoll;
+}

--- a/src/cameracommands/groundrollcameracommand.h
+++ b/src/cameracommands/groundrollcameracommand.h
@@ -20,6 +20,7 @@ class GroundRollCameraCommand : public CameraCommand
         /** Implementation methods */
         void set_response(float);
         float get_response();
+        virtual float get_last_roll();
     protected:
     private:
         std::vector<float> mPitchFilter;

--- a/src/cameracommands/levelheadcameracommand.cpp
+++ b/src/cameracommands/levelheadcameracommand.cpp
@@ -33,10 +33,20 @@ void LevelHeadCameraCommand::execute(CameraPosition &position, float elapsedTime
 	currentBank = XPLMGetDataf(mRollRef);
 
 	if (currentBank < 0) {
-		targetRoll = (std::max(-mMaxBankAngle, currentBank)) * (mResponse / 100.0f);
+                if (currentBank < -90.0f) {
+                        targetRoll = -mMaxBankAngle * (1.0 - ((-currentBank - 90.0f) / 90.0f)) * (mResponse / 100.0f);
+                }
+                else {
+                        targetRoll = (std::max(-mMaxBankAngle, currentBank)) * (mResponse / 100.0f);
+                }
 	} 
 	else {
-		targetRoll = (std::min(mMaxBankAngle, currentBank)) * (mResponse / 100.0f);
+                if (currentBank > 90.0f) {
+                        targetRoll = mMaxBankAngle * (1.0 - ((currentBank - 90.0f) / 90.0f)) * (mResponse / 100.0f);
+                }
+                else {
+                        targetRoll = (std::min(mMaxBankAngle, currentBank)) * (mResponse / 100.0f);
+                }
 	}
 
 	if (get_blend_ratio() < 1) {
@@ -76,4 +86,9 @@ void LevelHeadCameraCommand::set_max_bank(float maxBank)
 float LevelHeadCameraCommand::get_max_bank()
 {
 	return mMaxBankAngle;
+}
+
+float LevelHeadCameraCommand::get_last_roll()
+{
+  return mLastRoll;
 }

--- a/src/cameracommands/levelheadcameracommand.h
+++ b/src/cameracommands/levelheadcameracommand.h
@@ -18,6 +18,7 @@ public:
 	float get_response();
 	void set_max_bank(float maxBank);
 	float get_max_bank();
+        virtual float get_last_roll();
 protected:
 private:
 	float mLastRoll;

--- a/src/cameracommands/taxilookaheadcameracommand.cpp
+++ b/src/cameracommands/taxilookaheadcameracommand.cpp
@@ -140,3 +140,8 @@ float TaxiLookAheadCameraCommand::get_lean_response() const
 {
     return mLeanResponse;
 }
+
+float TaxiLookAheadCameraCommand::get_last_roll()
+{
+  return mLastRoll;
+}

--- a/src/cameracommands/taxilookaheadcameracommand.h
+++ b/src/cameracommands/taxilookaheadcameracommand.h
@@ -24,6 +24,7 @@ class TaxiLookAheadCameraCommand : public CameraCommand
         float get_turn_response() const;
         void set_lean_response(float);
         float get_lean_response() const;
+        virtual float get_last_roll();
     protected:
     private:
         std::vector<float> mRudderFilter;

--- a/src/cameracommands/touchdowncameracommand.cpp
+++ b/src/cameracommands/touchdowncameracommand.cpp
@@ -101,3 +101,8 @@ float TouchdownCameraCommand::get_response()
 {
     return mResponse;
 }
+
+float TouchdownCameraCommand::get_last_roll()
+{
+  return mLastRoll;
+}

--- a/src/cameracommands/touchdowncameracommand.h
+++ b/src/cameracommands/touchdowncameracommand.h
@@ -17,6 +17,7 @@ class TouchdownCameraCommand : public CameraCommand
         /** Implementation methods */
         void set_response(float);
         float get_response();
+        virtual float get_last_roll();
     protected:
     private:
         bool mPrevOnGround;

--- a/src/cameracontrol.h
+++ b/src/cameracontrol.h
@@ -100,6 +100,8 @@ private:
     std::vector<XPLMCommandRef> mStopCommands;
     std::vector<XPLMDataRef> mDrefs;
     unsigned int mStopCommandsSize;
+
+    float compensate_for_head_roll_drift(CameraPosition &currentPos);
 };
 
 #endif // CAMERACONTROL_H


### PR DESCRIPTION
This is a minimal changeset which addresses only two issues:

1.  The "permanent head roll offset bug" which develops over time, where after flying a while the pilot sees their head tilted left or right even while level.  The patch works by computing an offset from the headshake roll contributions and the current X-Plane head roll.  Note this fix has no way to know if other plugins are attempting to make contributions to pilot head roll.

2.  The abrupt shift in head roll while rotating upside down through the nadir.
