### PR TITLE
added damping sine wave to model nose wheel bump on touchdown

### DIFF
--- a/src/cameracommands/cameracommand.cpp
+++ b/src/cameracommands/cameracommand.cpp
@@ -56,6 +56,11 @@ void CameraCommand::on_disable()
 
 }
 
+void CameraCommand::on_receiving_message(XPLMPluginID, int, void*)
+{
+
+}
+
 float CameraCommand::get_blend_ratio() const
 {
     return mBlendTime / 2;

--- a/src/cameracommands/cameracommand.h
+++ b/src/cameracommands/cameracommand.h
@@ -1,6 +1,8 @@
 #ifndef CAMERACOMMAND_H
 #define CAMERACOMMAND_H
 
+#include <CHeaders/XPLM/XPLMDefs.h>
+
 #include "interfaces/ivisitable.h"
 #include "cameraposition.h"
 
@@ -19,6 +21,7 @@ class CameraCommand : public IVisitable
         virtual void on_view_changed(int);
         virtual void on_enable();
         virtual void on_disable();
+        virtual void on_receiving_message(XPLMPluginID, int, void*);
         void reset_blend();
     protected:
         float get_blend_ratio() const;

--- a/src/cameracommands/touchdowncameracommand.cpp
+++ b/src/cameracommands/touchdowncameracommand.cpp
@@ -137,7 +137,7 @@ void TouchdownCameraCommand::execute(CameraPosition &position, float elapsedTime
     } else {        
         float timeSinceNoseWheelTouchdown = XPLMGetElapsedTime() - noseWheelTouchdownTime;
         if (timeSinceNoseWheelTouchdown > 0 && timeSinceNoseWheelTouchdown < 1.5f) {
-            mLastY = bumpInitialAmplitude * exp(-bumpDecayRate * timeSinceNoseWheelTouchdown) * std::sin(2 * PI * bumpFrequency * timeSinceNoseWheelTouchdown);
+            mLastY = - bumpInitialAmplitude * exp(-bumpDecayRate * timeSinceNoseWheelTouchdown) * std::sin(2 * PI * bumpFrequency * timeSinceNoseWheelTouchdown);
             std::string s = "Bump Effect - Time since touch down: " + std::to_string(timeSinceNoseWheelTouchdown) +  " Y offset = " + std::to_string(mLastY) + "\n";
             XPLMDebugString(s.c_str());
         }

--- a/src/cameracommands/touchdowncameracommand.cpp
+++ b/src/cameracommands/touchdowncameracommand.cpp
@@ -3,17 +3,22 @@
 #include <cmath>
 #endif
 
+#include <string>
+
 #include <CHeaders/XPLM/XPLMDataAccess.h>
 #include <CHeaders/XPLM/XPLMUtilities.h>
 #include <CHeaders/XPLM/XPLMProcessing.h>
+#include <CHeaders/XPLM/XPLMPlugin.h>
 
 #include "cameracommands/touchdowncameracommand.h"
 #include "helpers.h"
 #include "cameraposition.h"
 #include "interfaces/ivisitor.h"
 
+#define MSG_ADD_DATAREF 0x01000000
+
 TouchdownCameraCommand::TouchdownCameraCommand()
-{
+{  
     mVerticalSpeedDataRef = XPLMFindDataRef("sim/flightmodel/position/vh_ind_fpm");
     mOnGroundDataRef = XPLMFindDataRef("sim/flightmodel/failures/onground_any");
     mRadioAltDataRef = XPLMFindDataRef("sim/flightmodel/position/y_agl");
@@ -24,7 +29,17 @@ TouchdownCameraCommand::TouchdownCameraCommand()
     mResponse = 25;
     mLastPitch = 0;
     mLastRoll = 0;
-    mLastX = 0;
+    mLastX = 0;    
+
+    // Nose bump
+    mNoseWheelPrevOnGround = true;
+    noseWheelOnGround[0] = 1;
+    mGearsOnGroundDataRef = XPLMFindDataRef("sim/flightmodel2/gear/on_ground");
+    mLastY = 0;
+    noseWheelTouchdownTime = 0;
+    bumpInitialAmplitude = 0.03f;
+    bumpDecayRate = 1.0f;
+    bumpFrequency = 1.0f;
 }
 
 TouchdownCameraCommand::~TouchdownCameraCommand()
@@ -32,10 +47,58 @@ TouchdownCameraCommand::~TouchdownCameraCommand()
     //dtor
 }
 
+void TouchdownCameraCommand::on_enable()
+{
+    int datarefEditorId = XPLMFindPluginBySignature("xplanesdk.examples.DataRefEditor");
+
+    mBumpInitialAmplitude = XPLMRegisterDataAccessor(
+        "simcoders/headshake/touchdowncamera/bump_initial_amplitude", xplmType_Float, 1, NULL, NULL,
+        [](void* refCon) -> float {
+            if (refCon) return reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpInitialAmplitude;
+            return 0.01f;
+        }, [](void* refCon, float value) -> void {
+            if (refCon) {
+                reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpInitialAmplitude = value;
+            }
+        }, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, this, this);
+    XPLMSendMessageToPlugin(datarefEditorId, MSG_ADD_DATAREF, (void*)"simcoders/headshake/touchdowncamera/bump_initial_amplitude");
+
+    mBumpDecayRate = XPLMRegisterDataAccessor(
+        "simcoders/headshake/touchdowncamera/bump_decay_rate", xplmType_Float, 1, NULL, NULL,
+        [](void* refCon) -> float {
+            if (refCon) return reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpDecayRate;
+            return 0.01f;
+        }, [](void* refCon, float value) -> void {
+            if (refCon) {
+                reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpDecayRate = value;
+            }
+        }, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, this, this);
+    XPLMSendMessageToPlugin(datarefEditorId, MSG_ADD_DATAREF, (void*)"simcoders/headshake/touchdowncamera/bump_decay_rate");
+
+    mBumpFrequency = XPLMRegisterDataAccessor(
+        "simcoders/headshake/touchdowncamera/bump_frequency", xplmType_Float, 1, NULL, NULL,
+        [](void* refCon) -> float {
+            if (refCon) return reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpFrequency;
+            return 0.01f;
+        }, [](void* refCon, float value) -> void {
+            if (refCon) {
+                reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpFrequency = value;
+            }
+        }, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, this, this);
+    XPLMSendMessageToPlugin(datarefEditorId, MSG_ADD_DATAREF, (void*)"simcoders/headshake/touchdowncamera/bump_frequency");
+}
+
+void TouchdownCameraCommand::on_disable()
+{
+    XPLMUnregisterDataAccessor(mBumpInitialAmplitude);
+    XPLMUnregisterDataAccessor(mBumpDecayRate);
+    XPLMUnregisterDataAccessor(mBumpFrequency);
+}
+
 void TouchdownCameraCommand::execute(CameraPosition &position, float elapsedTime)
 {
     CameraCommand::execute(position, elapsedTime);
-    
+
     float currentTime, touchdownshake, fastshake;
     const double PI = 3.141592653589793238463;
 
@@ -43,11 +106,14 @@ void TouchdownCameraCommand::execute(CameraPosition &position, float elapsedTime
     position.pitch -= mLastPitch;
     position.roll -= mLastRoll;
     position.x -= mLastX;
+    position.y -= mLastY;
 
     // Reset the state vars
     mLastPitch = 0;
     mLastRoll = 0;
     mLastX = 0;
+    
+    mLastY = 0;
 
     // Exit if disabled
     if (!pEnabled)
@@ -56,8 +122,25 @@ void TouchdownCameraCommand::execute(CameraPosition &position, float elapsedTime
     // Reset if not on ground
     if (!XPLMGetDatai(mOnGroundDataRef)) {
         // Reset only after climbing 1m agl
-        if (XPLMGetDataf(mRadioAltDataRef) > 1)
+        if (XPLMGetDataf(mRadioAltDataRef) > 1) {
             mPrevOnGround = false;
+            mNoseWheelPrevOnGround = false;
+        }            
+    }
+
+    // Bump effect
+    XPLMGetDatavi(mGearsOnGroundDataRef, noseWheelOnGround, 0, 1); // use better way to detect the nose wheel -> sim/aircraft/parts/acf_gear_ynodef
+    if(!mNoseWheelPrevOnGround && noseWheelOnGround[0] == 1) {
+        XPLMDebugString("Bump Effect - Nose wheel touched down.\n");
+        mNoseWheelPrevOnGround = true;
+        noseWheelTouchdownTime = XPLMGetElapsedTime();
+    } else {        
+        float timeSinceNoseWheelTouchdown = XPLMGetElapsedTime() - noseWheelTouchdownTime;
+        if (timeSinceNoseWheelTouchdown > 0 && timeSinceNoseWheelTouchdown < 1.5f) {
+            mLastY = bumpInitialAmplitude * exp(-bumpDecayRate * timeSinceNoseWheelTouchdown) * std::sin(2 * PI * bumpFrequency * timeSinceNoseWheelTouchdown);
+            std::string s = "Bump Effect - Time since touch down: " + std::to_string(timeSinceNoseWheelTouchdown) +  " Y offset = " + std::to_string(mLastY) + "\n";
+            XPLMDebugString(s.c_str());
+        }
     }
 
     // Touchdown effect
@@ -85,6 +168,7 @@ void TouchdownCameraCommand::execute(CameraPosition &position, float elapsedTime
     position.pitch += mLastPitch;
     position.roll += mLastRoll;
     position.x += mLastX;
+    position.y += mLastY;
 }
 
 void TouchdownCameraCommand::accept(IVisitor &visitor)

--- a/src/cameracommands/touchdowncameracommand.cpp
+++ b/src/cameracommands/touchdowncameracommand.cpp
@@ -43,6 +43,9 @@ TouchdownCameraCommand::TouchdownCameraCommand()
     bumpInitialAmplitude = 0.03f;
     bumpDecayRate = 1.5f;
     bumpFrequency = 1.0f;
+    bumpRollInitialAmplitude = 0.5f;
+    bumpRollDecayRate = 1.5f;
+    bumpRollFrequency = 1.0f;
 }
 
 TouchdownCameraCommand::~TouchdownCameraCommand()
@@ -89,6 +92,44 @@ void TouchdownCameraCommand::on_enable()
             }
         }, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, this, this);
     XPLMSendMessageToPlugin(datarefEditorId, MSG_ADD_DATAREF, (void*)"simcoders/headshake/touchdowncamera/bump_frequency");
+
+    // bump roll
+
+    mBumpRollInitialAmplitude = XPLMRegisterDataAccessor(
+        "simcoders/headshake/touchdowncamera/bump_roll_initial_amplitude", xplmType_Float, 1, NULL, NULL,
+        [](void* refCon) -> float {
+            if (refCon) return reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpRollInitialAmplitude;
+            return 0.01f;
+        }, [](void* refCon, float value) -> void {
+            if (refCon) {
+                reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpRollInitialAmplitude = value;
+            }
+        }, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, this, this);
+    XPLMSendMessageToPlugin(datarefEditorId, MSG_ADD_DATAREF, (void*)"simcoders/headshake/touchdowncamera/bump_roll_initial_amplitude");
+
+    mBumpDecayRate = XPLMRegisterDataAccessor(
+        "simcoders/headshake/touchdowncamera/bump_roll_decay_rate", xplmType_Float, 1, NULL, NULL,
+        [](void* refCon) -> float {
+            if (refCon) return reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpRollDecayRate;
+            return 0.01f;
+        }, [](void* refCon, float value) -> void {
+            if (refCon) {
+                reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpRollDecayRate = value;
+            }
+        }, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, this, this);
+    XPLMSendMessageToPlugin(datarefEditorId, MSG_ADD_DATAREF, (void*)"simcoders/headshake/touchdowncamera/bump_roll_decay_rate");
+
+    mBumpFrequency = XPLMRegisterDataAccessor(
+        "simcoders/headshake/touchdowncamera/bump_roll_frequency", xplmType_Float, 1, NULL, NULL,
+        [](void* refCon) -> float {
+            if (refCon) return reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpRollFrequency;
+            return 0.01f;
+        }, [](void* refCon, float value) -> void {
+            if (refCon) {
+                reinterpret_cast<TouchdownCameraCommand*>(refCon)-> bumpRollFrequency = value;
+            }
+        }, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, this, this);
+    XPLMSendMessageToPlugin(datarefEditorId, MSG_ADD_DATAREF, (void*)"simcoders/headshake/touchdowncamera/bump_roll_frequency");
 }
 
 void TouchdownCameraCommand::on_disable()
@@ -143,7 +184,8 @@ void TouchdownCameraCommand::execute(CameraPosition &position, float elapsedTime
             float timeSinceNoseWheelTouchdown = XPLMGetElapsedTime() - noseWheelTouchdownTime;
             if (timeSinceNoseWheelTouchdown > 0 && timeSinceNoseWheelTouchdown < 1.5f) {
                 mLastY = - bumpInitialAmplitude * exp(-bumpDecayRate * timeSinceNoseWheelTouchdown) * std::sin(2 * PI * bumpFrequency * timeSinceNoseWheelTouchdown);
-                std::string s = "Bump Effect - Time since touch down: " + std::to_string(timeSinceNoseWheelTouchdown) +  " Y offset = " + std::to_string(mLastY) + "\n";
+                mLastRoll = - bumpRollInitialAmplitude * exp(-bumpRollDecayRate * timeSinceNoseWheelTouchdown) * std::sin(2 * PI * bumpRollFrequency * timeSinceNoseWheelTouchdown);
+                std::string s = "Bump Effect - Time since touch down: " + std::to_string(timeSinceNoseWheelTouchdown) +  " Y offset = " + std::to_string(mLastY) + " Roll = " + std::to_string(mLastRoll) + "\n";
                 XPLMDebugString(s.c_str());
             }
         }
@@ -174,6 +216,7 @@ void TouchdownCameraCommand::execute(CameraPosition &position, float elapsedTime
     position.pitch += mLastPitch;
     position.roll += mLastRoll;
     position.x += mLastX;
+
     position.y += mLastY;
 }
 

--- a/src/cameracommands/touchdowncameracommand.h
+++ b/src/cameracommands/touchdowncameracommand.h
@@ -17,6 +17,14 @@ class TouchdownCameraCommand : public CameraCommand
         /** Implementation methods */
         void set_response(float);
         float get_response();
+
+        // Nose bump
+        XPLMDataRef mBumpInitialAmplitude;
+        XPLMDataRef mBumpDecayRate;
+        XPLMDataRef mBumpFrequency;
+        void on_enable() override;
+        void on_disable() override;
+
     protected:
     private:
         bool mPrevOnGround;
@@ -27,9 +35,19 @@ class TouchdownCameraCommand : public CameraCommand
         float mLastPitch;
         float mLastRoll;
         float mLastX;
+        float mLastY;
         XPLMDataRef mVerticalSpeedDataRef;
         XPLMDataRef mOnGroundDataRef;
         XPLMDataRef mRadioAltDataRef;
+
+        // Nose bump
+        float bumpInitialAmplitude;
+        float bumpDecayRate;
+        float bumpFrequency;
+        float noseWheelTouchdownTime;
+        bool mNoseWheelPrevOnGround;
+        int noseWheelOnGround[1];
+        XPLMDataRef mGearsOnGroundDataRef;
 };
 
 #endif // TOUCHDOWNCAMERACOMMAND_H

--- a/src/cameracommands/touchdowncameracommand.h
+++ b/src/cameracommands/touchdowncameracommand.h
@@ -24,6 +24,7 @@ class TouchdownCameraCommand : public CameraCommand
         XPLMDataRef mBumpFrequency;
         void on_enable() override;
         void on_disable() override;
+        void on_receiving_message(XPLMPluginID, int, void*) override;
 
     protected:
     private:
@@ -46,8 +47,11 @@ class TouchdownCameraCommand : public CameraCommand
         float bumpFrequency;
         float noseWheelTouchdownTime;
         bool mNoseWheelPrevOnGround;
-        int noseWheelOnGround[1];
+        int wheelsOnGround[10];
         XPLMDataRef mGearsOnGroundDataRef;
+        XPLMDataRef mWheelZPositionsDataRef;
+        short locateNoseWheelPosition(float (&wheelZPositions)[10]);
+        short noseWheelPosition;
 };
 
 #endif // TOUCHDOWNCAMERACOMMAND_H

--- a/src/cameracommands/touchdowncameracommand.h
+++ b/src/cameracommands/touchdowncameracommand.h
@@ -56,8 +56,12 @@ class TouchdownCameraCommand : public CameraCommand
         int wheelsOnGround[10];
         XPLMDataRef mGearsOnGroundDataRef;
         XPLMDataRef mWheelZPositionsDataRef;
+        XPLMDataRef mTrueThetaDataRef;
         short locateNoseWheelPosition(float (&wheelZPositions)[10]);
         short noseWheelPosition;
+        float lastSavedPitchAngle;
+        float lastSavedPitchAngleTime;
+        short pitchAngleCounter;
 };
 
 #endif // TOUCHDOWNCAMERACOMMAND_H

--- a/src/cameracommands/touchdowncameracommand.h
+++ b/src/cameracommands/touchdowncameracommand.h
@@ -22,6 +22,9 @@ class TouchdownCameraCommand : public CameraCommand
         XPLMDataRef mBumpInitialAmplitude;
         XPLMDataRef mBumpDecayRate;
         XPLMDataRef mBumpFrequency;
+        XPLMDataRef mBumpRollInitialAmplitude;
+        XPLMDataRef mBumpRollDecayRate;
+        XPLMDataRef mBumpRollFrequency;
         void on_enable() override;
         void on_disable() override;
         void on_receiving_message(XPLMPluginID, int, void*) override;
@@ -45,6 +48,9 @@ class TouchdownCameraCommand : public CameraCommand
         float bumpInitialAmplitude;
         float bumpDecayRate;
         float bumpFrequency;
+        float bumpRollInitialAmplitude;
+        float bumpRollDecayRate;
+        float bumpRollFrequency;
         float noseWheelTouchdownTime;
         bool mNoseWheelPrevOnGround;
         int wheelsOnGround[10];

--- a/src/cameracontrol.cpp
+++ b/src/cameracontrol.cpp
@@ -407,6 +407,14 @@ void CameraControl::reset_view()
 	}
 }
 
+void CameraControl::on_receiving_message(XPLMPluginID pluginId, int message, void* param) 
+{
+    // Send the on_receiving_message to the commands
+    for (auto command : mCommands) {
+        command->on_receiving_message(pluginId, message, param);
+    }
+}
+
 void CameraControl::freeze()
 {
     mFreezed1 = true;

--- a/src/cameracontrol.h
+++ b/src/cameracontrol.h
@@ -19,6 +19,7 @@ public:
     void accept(IVisitor&);
     void on_enable();
     void on_disable();
+    void on_receiving_message(XPLMPluginID, int, void*);
     bool get_multimonitor_compatibility() const;
     void set_multimonitor_compatibility(bool);
     bool error();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,11 +72,11 @@ PLUGIN_API void XPluginDisable(void)
 }
 
 PLUGIN_API void XPluginReceiveMessage(
-    XPLMPluginID,
-    long,
-    void*)
+    XPLMPluginID pluginId,
+    int message,
+    void* param)
 {
-
+    CameraControl::get_instance()->on_receiving_message(pluginId, message, param);
 }
 
 float FlightLoopCallback(


### PR DESCRIPTION
This is a draft aiming to add the bump effect when the nose wheel touches down.

I added a damping sine wave to model the nose wheel bump on touchdown. 
Since I'm not a real life pilot, I'm not quite sure how big the effect is and which variables might affect it (I imagine many, like wheel pressure and nose down speed, if at all possible to be determined via a dataref, tho we might want to limit the model to a few). For this reason, every damping function parameters are exposed as dataref so that they can be modified and tested in game. It would be nice if someone with real life experience could try it and tell me what parameters feel the best. 

The function has the form: 

> y(t) = - A * e^-(L*t) * sin(2 * PI * F * t)

where:

- y: is the camera position offset on the y axis
- A: is the initial amplitude (`simcoders/headshake/touchdowncamera/bump_initial_amplitude`) [default value: 0.03]
- L: is the decay rate (`simcoders/headshake/touchdowncamera/bump_decay_rate`) [default value: 1]
- F: is the frequency (`simcoders/headshake/touchdowncamera/bump_frequency`) [default value: 1]

At the moment, the nose wheel touchdown check is performed assuming the nose wheel is the first in the `sim/flightmodel2/gear/on_ground` array dataref, but we might want to perform a better check, testing the position of each wheel using the `sim/aircraft/parts/acf_gear_znodef` in order to establish which wheel is the furthest forward. 

All code is unfinished and unpolished, everything will be cleaned up in future commits.

Closes #28 