### PR TITLE
Make work with gLoaded Camera

### DIFF
--- a/src/cameracontrol.cpp
+++ b/src/cameracontrol.cpp
@@ -67,6 +67,7 @@ CameraControl::CameraControl()
     mStopCommand = XPLMCreateCommand("simcoders/headshake/stop", "Stop HeadShake. It will restart once the view is not controlled anymore by another plugin.");
     // Fill the datarefs
     mCinemaVeriteDataRef = XPLMFindDataRef("sim/graphics/view/cinema_verite");
+    mG_LoadedCameraDataRef = XPLMFindDataRef("sim/graphics/view/gloaded_internal_cam");
     mPausedDataRef = XPLMFindDataRef("sim/time/paused");
     mViewTypeDataRef = XPLMFindDataRef("sim/graphics/view/view_type");
     mHeadHeadingDataRef = XPLMFindDataRef("sim/graphics/view/pilots_head_psi");
@@ -431,7 +432,8 @@ float CameraControl::control(float elapsedTime)
         }
     }
     // Make sure that we're in the virtual cockpit, cinema verite is not active and the sim is not paused
-    mError = XPLMGetDatai(mCinemaVeriteDataRef) > 0;
+    // Note: if gLoaded camera is defined then we don't care about the state of CinemaVerite
+    mError = (mG_LoadedCameraDataRef == nullptr) ? XPLMGetDatai(mCinemaVeriteDataRef) > 0 : false;
     if (cameraType != 1026 || XPLMGetDatai(mPausedDataRef) || mError) {
         return 1;
     }

--- a/src/cameracontrol.h
+++ b/src/cameracontrol.h
@@ -77,6 +77,7 @@ private:
     /** DataRefs */
     XPLMDataRef mPausedDataRef;
     XPLMDataRef mCinemaVeriteDataRef;
+    XPLMDataRef mG_LoadedCameraDataRef;
     XPLMDataRef mViewTypeDataRef;
     XPLMDataRef mHeadHeadingDataRef;
     XPLMDataRef mHeadPitchDataRef;


### PR DESCRIPTION
Make work with X-Pane 12 gLoaded Camera.

If the X-Plane 12 gLoaded camera dataref is defined then we don't disable HeadShake when the CinemaVeriti flag is set. This is because Laminar has the CinemaVeriti tied to and in sync with the gLoaded camera dataref.

This allows users to mix HeadShake effects with the gLoaded camera effects.

Note: Please make sure to build the OSX version with both the Intel and Mac Silicon architectures. I get the impression people had to use Rosetta on M1 Macs with the old released version. 